### PR TITLE
moving from pixmap to cimg via magick library

### DIFF
--- a/grabImageLabels.R
+++ b/grabImageLabels.R
@@ -1,25 +1,58 @@
 library(qdapRegex)
+library(pixmap)
 library(magick)
-## Instead of "/home/usdandres/Downloads/" specify your directory,
-##  where you downloaded the data.
+
 wd <- getwd()
 fullDir = paste(wd,"/scale4Faces/",sep="")
 print(fullDir)
 all.files <- list.files(path=fullDir)
 
 n.imageIndex = 1
-emotionVector <- NULL
-positionVector <- NULL
+emotionLabel <- NULL
+positionLabel <- NULL
 pixelMap <- NULL
+images <- NULL
 
 for (fileName in all.files){
   currVec = rm_between(fileName, "_", "_", extract=TRUE)
-  emotionVector[n.imageIndex] <- currVec[[1]][2]
-  positionVector[n.imageIndex] <- currVec[[1]][1]
+  emotionLabel[n.imageIndex] <- currVec[[1]][2]
+  positionLabel[n.imageIndex] <- currVec[[1]][1]
   
-  # pixelMapVal@grey is showing swapped dimensions
-  pixelMapVal <- read.pnm(paste(fullDir,fileName,sep=""))
-  pixelMap[[n.imageIndex]] <- pixelMapVal@grey
+  magickObj <- image_read(paste(fullDir,fileName,sep=""))
+  cimgObj <- magick2cimg(magickObj)
+  
+  pixelMap[[n.imageIndex]] <- cimgObj
   n.imageIndex <- n.imageIndex + 1
 }
+
+
+# # create magick object (needed to read pgm extension)
+# testImagepath = paste(fullDir,"an2i_left_angry_open_4.pgm",sep="")
+# parrots <- image_read(testImagepath)
+# bitmap <- parrots[[1]]
+# parrots
+# 
+# # convert magick to cimg to work with professor's code/ more functionality https://cran.r-project.org/web/packages/imager/vignettes/gettingstarted.html
+# cimg <- magick2cimg(parrots)
+# # plot image
+# plot(cimg)
+# bdf <- as.data.frame(cimg)  #960 Obs = 32*30
+# 
+
+
+
+
+
+par(mfrow=c(2,2))
+ plot(pixelMap[[1]],
+      main=paste("Size:", dim(pixelMap[[1]])[1],"x", dim(pixelMap[[1]])[2]))
+ plot(pixelMap[[2]],
+      main=paste("Size:", dim(pixelMap[[2]])[1],"x", dim(pixelMap[[2]])[2]))
+ plot(pixelMap[[3]],
+      main=paste("Size:", dim(pixelMap[[3]])[1],"x", dim(pixelMap[[3]])[2]))
+ plot(pixelMap[[4]],
+      main=paste("Size:", dim(pixelMap[[4]])[1],"x", dim(pixelMap[[4]])[2]))
+par(mfrow=c(1,1))
+
+
 


### PR DESCRIPTION
We were previously using pixmap, but I decided to go back and use cimg. The reason being was that I was not sure on how to store a frame of pixmap objects to plot the actual image. We were only able to store a frame of the greyscale maps. Also if we use cimg, we have more supportability via prof code and online documentation https://cran.r-project.org/web/packages/imager/vignettes/gettingstarted.html